### PR TITLE
Fix port number switch

### DIFF
--- a/ssh_enum.py
+++ b/ssh_enum.py
@@ -119,7 +119,7 @@ else:
 	multiplier = 20000
 
 if options.port:
-	port = int(port)
+	port = int(options.port)
 else:
 	port = 22
 


### PR DESCRIPTION
Fix for port numbers specified as a command-line option.

for:
python ssh_enum.py -u names.txt -i 127.0.0.1 -p 1025

error was:
NameError: name 'port' is not defined